### PR TITLE
Change bundles names to dynamic values based on entries keys.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,5 +6,5 @@
   <body>
     <div class="container"></div>
   </body>
-  <script src="/bundle.js"></script>
+  <script src="/index.bundle.js"></script>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 module.exports = {
-  entry: [
-    './src/index.js'
-  ],
+  entries: {
+    index: './src/index.js'
+  },
   output: {
     path: __dirname,
     publicPath: '/',
-    filename: 'bundle.js'
+    filename: '[name].bundle.js'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Motivation: for the very probable case, when you need one more bundle, it will be easier to configure it:

``` javascript
entries: {
  main: './src/index.js',  // -> /main.bundle.js
  login: './scr/login.js'  // -> /login.bundle.js
}
```
